### PR TITLE
Fixed required fields for iDeal transaction report

### DIFF
--- a/src/TreeHouse/BuckarooBundle/Report/AbstractTransactionReport.php
+++ b/src/TreeHouse/BuckarooBundle/Report/AbstractTransactionReport.php
@@ -5,43 +5,66 @@ namespace TreeHouse\BuckarooBundle\Report;
 abstract class AbstractTransactionReport implements ReportInterface
 {
     /**
+     * The invoicenumber as provided in the request.
+     *
      * @var string
      */
     private $invoiceNumber;
 
     /**
+     * The status code of the transaction.
+     *
      * @var int
      */
     private $statusCode;
 
     /**
+     * A detail status code which provides an yes extra explanation for the
+     * current status of the transaction.
+     *
      * @var string
      */
     private $statusCodeDetail;
 
     /**
+     * A message explaining the current (detail)status.
+     *
      * @var string
      */
     private $statusMessage;
 
     /**
+     * The time at which the payment received it current status.
+     *
      * @var \DateTime
      */
     private $timestamp;
+
+    /**
+     * One or more transaction keys. One key if only a transaction was created
+     * or a payment with one underlying transaction. Multiple keys if one
+     * payment has multiple underlying transactions. List of keys is comma
+     * separated.
+     *
+     * @var string
+     */
+    private $transactions;
 
     /**
      * @param string    $invoiceNumber
      * @param int       $statusCode
      * @param string    $statusMessage
      * @param \DateTime $timestamp
+     * @param string    $transactions
      * @param string    $statusCodeDetail
      */
-    private function __construct($invoiceNumber, $statusCode, $statusMessage, \DateTime $timestamp, $statusCodeDetail = null)
+    private function __construct($invoiceNumber, $statusCode, $statusMessage, \DateTime $timestamp, $transactions, $statusCodeDetail = null)
     {
         $this->invoiceNumber = $invoiceNumber;
         $this->statusCode = $statusCode;
         $this->statusMessage = $statusMessage;
         $this->timestamp = $timestamp;
+        $this->transactions = $transactions;
         $this->statusCodeDetail = $statusCodeDetail;
     }
 
@@ -50,17 +73,24 @@ abstract class AbstractTransactionReport implements ReportInterface
      */
     public static function create(array $data)
     {
-        static::ensureOptionalFields(['BRQ_STATUSCODE_DETAIL'], $data);
-        static::checkRequiredFields(
-            ['BRQ_INVOICENUMBER', 'BRQ_STATUSCODE', 'BRQ_STATUSMESSAGE', 'BRQ_TIMESTAMP'],
-            $data
-        );
+        $requiredFields = [
+            'BRQ_INVOICENUMBER',
+            'BRQ_STATUSCODE',
+            'BRQ_STATUSMESSAGE',
+            'BRQ_TIMESTAMP',
+            'BRQ_TRANSACTIONS',
+        ];
+        $optionalFields = ['BRQ_STATUSCODE_DETAIL'];
+
+        static::checkRequiredFields($requiredFields, $data);
+        static::ensureOptionalFields($optionalFields, $data);
 
         return new static(
             $data['BRQ_INVOICENUMBER'],
             $data['BRQ_STATUSCODE'],
             $data['BRQ_STATUSMESSAGE'],
             new \DateTime($data['BRQ_TIMESTAMP']),
+            $data['BRQ_TRANSACTIONS'],
             $data['BRQ_STATUSCODE_DETAIL']
         );
     }
@@ -136,6 +166,14 @@ abstract class AbstractTransactionReport implements ReportInterface
     public function getTimestamp()
     {
         return $this->timestamp;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTransactions()
+    {
+        return $this->transactions;
     }
 
     /**

--- a/src/TreeHouse/BuckarooBundle/Report/AbstractTransactionReport.php
+++ b/src/TreeHouse/BuckarooBundle/Report/AbstractTransactionReport.php
@@ -50,12 +50,18 @@ abstract class AbstractTransactionReport implements ReportInterface
      */
     public static function create(array $data)
     {
+        static::ensureOptionalFields(['BRQ_STATUSCODE_DETAIL'], $data);
+        static::checkRequiredFields(
+            ['BRQ_INVOICENUMBER', 'BRQ_STATUSCODE', 'BRQ_STATUSMESSAGE', 'BRQ_TIMESTAMP'],
+            $data
+        );
+
         return new static(
             $data['BRQ_INVOICENUMBER'],
             $data['BRQ_STATUSCODE'],
             $data['BRQ_STATUSMESSAGE'],
             new \DateTime($data['BRQ_TIMESTAMP']),
-            isset($data['BRQ_STATUSCODE_DETAIL']) ? $data['BRQ_STATUSCODE_DETAIL'] : null
+            $data['BRQ_STATUSCODE_DETAIL']
         );
     }
 
@@ -130,5 +136,38 @@ abstract class AbstractTransactionReport implements ReportInterface
     public function getTimestamp()
     {
         return $this->timestamp;
+    }
+
+    /**
+     * Checks that the given fields are in the array and are not `null`.
+     *
+     * @param array $fields
+     * @param array $data
+     *
+     * @throws \InvalidArgumentException
+     */
+    protected static function checkRequiredFields(array $fields, array $data)
+    {
+        foreach ($fields as $field) {
+            if (!isset($data[$field])) {
+                throw new \InvalidArgumentException(sprintf('Missing field: %s', $field));
+            }
+        }
+    }
+
+    /**
+     * Ensures that the given fields exist in the $data array.
+     * If a field does not exist, it will be added with a `null` value.
+     *
+     * @param array $fields
+     * @param array $data
+     */
+    protected static function ensureOptionalFields(array $fields, array &$data)
+    {
+        foreach ($fields as $field) {
+            if (!isset($data[$field])) {
+                $data[$field] = null;
+            }
+        }
     }
 }

--- a/src/TreeHouse/BuckarooBundle/Report/IdealTransactionReport.php
+++ b/src/TreeHouse/BuckarooBundle/Report/IdealTransactionReport.php
@@ -92,32 +92,31 @@ class IdealTransactionReport extends AbstractTransactionReport
      */
     public static function create(array $data)
     {
-        $report = parent::create($data);
-
         $requiredFields = [
             'BRQ_AMOUNT',
             'BRQ_CURRENCY',
-            'BRQ_CUSTOMER_NAME',
             'BRQ_DESCRIPTION',
-            'BRQ_PAYER_HASH',
             'BRQ_PAYMENT',
             'BRQ_PAYMENT_METHOD',
-            'BRQ_SERVICE_IDEAL_CONSUMERBIC',
-            'BRQ_SERVICE_IDEAL_CONSUMERIBAN',
             'BRQ_SERVICE_IDEAL_CONSUMERISSUER',
-            'BRQ_SERVICE_IDEAL_CONSUMERNAME',
             'BRQ_TRANSACTIONS',
         ];
 
-        foreach ($requiredFields as $field) {
-            if (!isset($data[$field])) {
-                throw new \InvalidArgumentException(sprintf('Missing field: %s', $field));
-            }
-        }
+        $optionalFields = [
+            'BRQ_CUSTOMER_NAME',
+            'BRQ_PAYER_HASH',
+            'BRQ_SERVICE_IDEAL_CONSUMERBIC',
+            'BRQ_SERVICE_IDEAL_CONSUMERIBAN',
+            'BRQ_SERVICE_IDEAL_CONSUMERNAME',
+        ];
 
+        static::checkRequiredFields($requiredFields, $data);
+        static::ensureOptionalFields($optionalFields, $data);
+
+        $report = parent::create($data);
         $report->amount = new Money(intval($data['BRQ_AMOUNT'] * 100), new Currency($data['BRQ_CURRENCY']));
-        $report->customerName = $data['BRQ_CUSTOMER_NAME'];
         $report->description = $data['BRQ_DESCRIPTION'];
+        $report->customerName = $data['BRQ_CUSTOMER_NAME'];
         $report->payerHash = $data['BRQ_PAYER_HASH'];
         $report->payment = $data['BRQ_PAYMENT'];
         $report->paymentMethod = $data['BRQ_PAYMENT_METHOD'];

--- a/src/TreeHouse/BuckarooBundle/Report/IdealTransactionReport.php
+++ b/src/TreeHouse/BuckarooBundle/Report/IdealTransactionReport.php
@@ -78,14 +78,6 @@ class IdealTransactionReport extends AbstractTransactionReport
     private $consumerIssuer;
 
     /**
-     * One or more transaction keys. One key if only a transaction was created or a payment with one underlying transaction.
-     * Multiple keys if one payment has multiple underlying transactions. List of keys is comma separated.
-     *
-     * @var string
-     */
-    private $transactions;
-
-    /**
      * @inheritdoc
      *
      * @return $this
@@ -99,7 +91,6 @@ class IdealTransactionReport extends AbstractTransactionReport
             'BRQ_PAYMENT',
             'BRQ_PAYMENT_METHOD',
             'BRQ_SERVICE_IDEAL_CONSUMERISSUER',
-            'BRQ_TRANSACTIONS',
         ];
 
         $optionalFields = [
@@ -115,8 +106,8 @@ class IdealTransactionReport extends AbstractTransactionReport
 
         $report = parent::create($data);
         $report->amount = new Money(intval($data['BRQ_AMOUNT'] * 100), new Currency($data['BRQ_CURRENCY']));
-        $report->description = $data['BRQ_DESCRIPTION'];
         $report->customerName = $data['BRQ_CUSTOMER_NAME'];
+        $report->description = $data['BRQ_DESCRIPTION'];
         $report->payerHash = $data['BRQ_PAYER_HASH'];
         $report->payment = $data['BRQ_PAYMENT'];
         $report->paymentMethod = $data['BRQ_PAYMENT_METHOD'];
@@ -124,7 +115,6 @@ class IdealTransactionReport extends AbstractTransactionReport
         $report->consumerIban = $data['BRQ_SERVICE_IDEAL_CONSUMERIBAN'];
         $report->consumerIssuer = $data['BRQ_SERVICE_IDEAL_CONSUMERISSUER'];
         $report->consumerName = $data['BRQ_SERVICE_IDEAL_CONSUMERNAME'];
-        $report->transactions = $data['BRQ_TRANSACTIONS'];
 
         return $report;
     }
@@ -207,13 +197,5 @@ class IdealTransactionReport extends AbstractTransactionReport
     public function getConsumerIssuer()
     {
         return $this->consumerIssuer;
-    }
-
-    /**
-     * @return string
-     */
-    public function getTransactions()
-    {
-        return $this->transactions;
     }
 }

--- a/src/TreeHouse/BuckarooBundle/Report/SimpleSepaDirectDebitTransactionCreditReport.php
+++ b/src/TreeHouse/BuckarooBundle/Report/SimpleSepaDirectDebitTransactionCreditReport.php
@@ -28,16 +28,17 @@ class SimpleSepaDirectDebitTransactionCreditReport extends AbstractSimpleSepaDir
             'BRQ_PAYMENT',
             'BRQ_TRANSACTION_METHOD',
             'BRQ_TRANSACTION_TYPE',
-            'BRQ_TRANSACTIONS',
         ];
 
         static::checkRequiredFields($requiredFields, $data);
 
         if ('C008' === $data['BRQ_TRANSACTION_TYPE']) {
             throw new \RuntimeException(
-                'Expected to create a %s for a credit transaction. Got a regular transaction (type C008) instead. ' .
-                'Are you attempting to create a SimpleSepaDirectDebitTransactionDebitReport?',
-                get_class()
+                sprintf(
+                    'Expected to create a %s for a credit transaction. Got a regular transaction (type C008) instead. ' .
+                    'Are you attempting to create a SimpleSepaDirectDebitTransactionDebitReport?',
+                    static::class
+                )
             );
         }
 

--- a/src/TreeHouse/BuckarooBundle/Report/SimpleSepaDirectDebitTransactionCreditReport.php
+++ b/src/TreeHouse/BuckarooBundle/Report/SimpleSepaDirectDebitTransactionCreditReport.php
@@ -20,16 +20,6 @@ class SimpleSepaDirectDebitTransactionCreditReport extends AbstractSimpleSepaDir
      */
     public static function create(array $data)
     {
-        $report = parent::create($data);
-
-        if ('C008' === $data['BRQ_TRANSACTION_TYPE']) {
-            throw new \RuntimeException(
-                'Expected to create a %s for a credit transaction. Got a regular transaction (type C008) instead. ' .
-                'Are you attempting to create a SimpleSepaDirectDebitTransactionDebitReport?',
-                get_class()
-            );
-        }
-
         $requiredFields = [
             'BRQ_AMOUNT_CREDIT',
             'BRQ_CURRENCY',
@@ -41,12 +31,17 @@ class SimpleSepaDirectDebitTransactionCreditReport extends AbstractSimpleSepaDir
             'BRQ_TRANSACTIONS',
         ];
 
-        foreach ($requiredFields as $field) {
-            if (!isset($data[$field])) {
-                throw new \InvalidArgumentException(sprintf('Missing field: %s', $field));
-            }
+        static::checkRequiredFields($requiredFields, $data);
+
+        if ('C008' === $data['BRQ_TRANSACTION_TYPE']) {
+            throw new \RuntimeException(
+                'Expected to create a %s for a credit transaction. Got a regular transaction (type C008) instead. ' .
+                'Are you attempting to create a SimpleSepaDirectDebitTransactionDebitReport?',
+                get_class()
+            );
         }
 
+        $report = parent::create($data);
         $report->amount = new Money(intval($data['BRQ_AMOUNT_CREDIT'] * 100), new Currency($data['BRQ_CURRENCY']));
         $report->customerName = $data['BRQ_CUSTOMER_NAME'];
         $report->invoiceNumber = $data['BRQ_INVOICENUMBER'];

--- a/src/TreeHouse/BuckarooBundle/Report/SimpleSepaDirectDebitTransactionDebitReport.php
+++ b/src/TreeHouse/BuckarooBundle/Report/SimpleSepaDirectDebitTransactionDebitReport.php
@@ -14,17 +14,6 @@ class SimpleSepaDirectDebitTransactionDebitReport extends AbstractSimpleSepaDire
      */
     public static function create(array $data)
     {
-        $report = parent::create($data);
-
-        if ('C008' !== $data['BRQ_TRANSACTION_TYPE']) {
-            throw new \RuntimeException(
-                'Expected to create a %s for a debit transaction. Got a credit transaction (type %s) instead. ' .
-                'Are you attempting to create a SimpleSepaDirectDebitTransactionDebitReport?',
-                get_class(),
-                $report->getTransactionType()
-            );
-        }
-
         $requiredFields = [
             'BRQ_AMOUNT',
             'BRQ_CURRENCY',
@@ -42,12 +31,18 @@ class SimpleSepaDirectDebitTransactionDebitReport extends AbstractSimpleSepaDire
             'BRQ_TRANSACTIONS',
         ];
 
-        foreach ($requiredFields as $field) {
-            if (!isset($data[$field])) {
-                throw new \InvalidArgumentException(sprintf('Missing field: %s', $field));
-            }
+        static::checkRequiredFields($requiredFields, $data);
+
+        if ('C008' !== $data['BRQ_TRANSACTION_TYPE']) {
+            throw new \RuntimeException(
+                'Expected to create a %s for a debit transaction. Got a credit transaction (type %s) instead. ' .
+                'Are you attempting to create a SimpleSepaDirectDebitTransactionDebitReport?',
+                get_class(),
+                $data['BRQ_TRANSACTION_TYPE']
+            );
         }
 
+        $report = parent::create($data);
         $report->amount = new Money(intval($data['BRQ_AMOUNT'] * 100), new Currency($data['BRQ_CURRENCY']));
         $report->customerName = $data['BRQ_CUSTOMER_NAME'];
         $report->invoiceNumber = $data['BRQ_INVOICENUMBER'];

--- a/src/TreeHouse/BuckarooBundle/Report/SimpleSepaDirectDebitTransactionDebitReport.php
+++ b/src/TreeHouse/BuckarooBundle/Report/SimpleSepaDirectDebitTransactionDebitReport.php
@@ -28,17 +28,18 @@ class SimpleSepaDirectDebitTransactionDebitReport extends AbstractSimpleSepaDire
             'BRQ_STARTRECURRENT',
             'BRQ_TRANSACTION_METHOD',
             'BRQ_TRANSACTION_TYPE',
-            'BRQ_TRANSACTIONS',
         ];
 
         static::checkRequiredFields($requiredFields, $data);
 
         if ('C008' !== $data['BRQ_TRANSACTION_TYPE']) {
             throw new \RuntimeException(
-                'Expected to create a %s for a debit transaction. Got a credit transaction (type %s) instead. ' .
-                'Are you attempting to create a SimpleSepaDirectDebitTransactionDebitReport?',
-                get_class(),
-                $data['BRQ_TRANSACTION_TYPE']
+                sprintf(
+                    'Expected to create a %s for a debit transaction. Got a credit transaction (type %s) instead. ' .
+                    'Are you attempting to create a SimpleSepaDirectDebitTransactionDebitReport?',
+                    static::class,
+                    $data['BRQ_TRANSACTION_TYPE']
+                )
             );
         }
 
@@ -55,7 +56,6 @@ class SimpleSepaDirectDebitTransactionDebitReport extends AbstractSimpleSepaDire
         $report->startRecurrent = (bool) $data['BRQ_STARTRECURRENT'];
         $report->transactionMethod = $data['BRQ_TRANSACTION_METHOD'];
         $report->transactionType = $data['BRQ_TRANSACTION_TYPE'];
-        $report->transactions = $data['BRQ_TRANSACTIONS'];
 
         return $report;
     }

--- a/src/TreeHouse/BuckarooBundle/Response/ResponseInterface.php
+++ b/src/TreeHouse/BuckarooBundle/Response/ResponseInterface.php
@@ -26,14 +26,14 @@ interface ResponseInterface
      *
      * @see http://support.buckaroo.nl/index.php/NVP_Koppeling
      */
-    const RESULT_SUCCESS = 'Success';         // action or transaction was successful
-    const RESULT_REJECT = 'Reject';          // action or transaction was rejected by Buckaroo or the acquirer
-    const RESULT_CANCEL = 'Cancel';          // action or transaction was cancelled
-    const RESULT_FAIL = 'Fail';            // action or transaction has failed
-    const RESULT_PENDING = 'Pending';         // action or transaction is pending (updates can be pushed later)
-    const RESULT_ACTION_REQUIRED = 'ActionRequired';  // an action must be performed before the transaction can be completed (i.e. a redirect)
-    const RESULT_WAITING = 'Waiting';         // the transaction is waiting for the customer (unsure if this is the last status)
-    const RESULT_ON_HOLD = 'OnHold';          // the transaction has been put on hold for some reason (i.e. not enough credit), this is not a final status
+    const RESULT_SUCCESS = 'Success';                   // action or transaction was successful
+    const RESULT_REJECT = 'Reject';                     // action or transaction was rejected by Buckaroo or the acquirer
+    const RESULT_CANCEL = 'Cancel';                     // action or transaction was cancelled
+    const RESULT_FAIL = 'Fail';                         // action or transaction has failed
+    const RESULT_PENDING = 'Pending';                   // action or transaction is pending (updates can be pushed later)
+    const RESULT_ACTION_REQUIRED = 'ActionRequired';    // an action must be performed before the transaction can be completed (i.e. a redirect)
+    const RESULT_WAITING = 'Waiting';                   // the transaction is waiting for the customer (unsure if this is the last status)
+    const RESULT_ON_HOLD = 'OnHold';                    // the transaction has been put on hold for some reason (i.e. not enough credit), this is not a final status
 
     /**
      * @param array $data

--- a/tests/TreeHouse/BuckarooBundle/Tests/Report/IdealTransactionReportTest.php
+++ b/tests/TreeHouse/BuckarooBundle/Tests/Report/IdealTransactionReportTest.php
@@ -8,50 +8,237 @@ use TreeHouse\BuckarooBundle\Response\ResponseInterface;
 
 class IdealTransactionReportTest extends \PHPUnit_Framework_TestCase
 {
+    private $amount = 12.34;
+    private $currency = 'EUR';
+    private $customerName = 'Pietje Puk';
+    private $description = 'This is an example of an iDeal transaction report';
+    private $invoiceNumber = 123456789;
+    private $payerHash = 'ed930548902988eb872ce58903105cc9bd7040fa6a08dfa53bcd086cd6973398af78b969857ca0b1d2fef1132981d633135437860a0fda36305cdd14b713f92';
+    private $payment = 'B62963F863AF42CFB8B2CC22125DD110';
+    private $paymentMethod = 'ideal';
+    private $consumerBic = 'INGNL2U';
+    private $consumerIban = 'NL12ING0123456789';
+    private $consumerIssuer = 'ING';
+    private $consumerName = 'P. Puk';
+    private $timestamp = '2015-01-01 12:34:56';
+    private $transactions = 'ADE9AB5949924D9482E10AD1920A324D';
+    private $signature = '5TzIZWifLXr2gtXlYoc93dewnnY3noZWakZhtiO8';
+
     /**
      * @test
      */
-    public function it_can_be_created()
+    public function it_can_create_a_success_report()
     {
-        $data = [
-            'BRQ_INVOICENUMBER' => 123456789,
-            'BRQ_STATUSCODE' => ResponseInterface::STATUS_FAILURE,
-            'BRQ_STATUSCODE_DETAIL' => 'C620',
-            'BRQ_STATUSMESSAGE' => 'This is the status',
-            'BRQ_TIMESTAMP' => '2015-01-01 12:34:56',
+        $statuscode = ResponseInterface::STATUS_SUCCESS;
+        $statuscodeDetail = 'S001';
+        $statusMessage = 'Transaction successfully processed';
 
-            'BRQ_AMOUNT' => 12.34,
-            'BRQ_CURRENCY' => 'EUR',
-            'BRQ_CUSTOMER_NAME' => 'Pietje Puk',
-            'BRQ_DESCRIPTION' => 'This is an example of an iDeal transaction report',
-            'BRQ_PAYER_HASH' => 'ed930548902988eb872ce58903105cc9bd7040fa6a08dfa53bcd086cd6973398af78b969857ca0b1d2fef1132981d633135437860a0fda36305cdd14b713f92',
-            'BRQ_PAYMENT' => 'B62963F863AF42CFB8B2CC22125DD110',
-            'BRQ_PAYMENT_METHOD' => 'ideal',
-            'BRQ_SERVICE_IDEAL_CONSUMERBIC' => 'INGNL2U',
-            'BRQ_SERVICE_IDEAL_CONSUMERIBAN' => 'NL12ING0123456789',
-            'BRQ_SERVICE_IDEAL_CONSUMERISSUER' => 'ING',
-            'BRQ_SERVICE_IDEAL_CONSUMERNAME' => 'P. Puk',
-            'BRQ_TRANSACTIONS' => 'ADE9AB5949924D9482E10AD1920A324D',
+        $data = [
+            'BRQ_AMOUNT' => $this->amount,
+            'BRQ_CURRENCY' => $this->currency,
+            'BRQ_CUSTOMER_NAME' => $this->customerName,
+            'BRQ_DESCRIPTION' => $this->description,
+            'BRQ_INVOICENUMBER' => $this->invoiceNumber,
+            'BRQ_PAYER_HASH' => $this->payerHash,
+            'BRQ_PAYMENT' => $this->payment,
+            'BRQ_PAYMENT_METHOD' => $this->paymentMethod,
+            'BRQ_SERVICE_IDEAL_CONSUMERBIC' => $this->consumerBic,
+            'BRQ_SERVICE_IDEAL_CONSUMERIBAN' => $this->consumerIban,
+            'BRQ_SERVICE_IDEAL_CONSUMERISSUER' => $this->consumerIssuer,
+            'BRQ_SERVICE_IDEAL_CONSUMERNAME' => $this->consumerName,
+            'BRQ_STATUSCODE' => $statuscode,
+            'BRQ_STATUSCODE_DETAIL' => $statuscodeDetail,
+            'BRQ_STATUSMESSAGE' => $statusMessage,
+            'BRQ_TIMESTAMP' => $this->timestamp,
+            'BRQ_TRANSACTIONS' => $this->transactions,
+            'BRQ_SIGNATURE' => $this->signature,
+
         ];
 
         $report = IdealTransactionReport::create($data);
 
         $this->assertInstanceOf(ReportInterface::class, $report);
-        $this->assertSame($data['BRQ_INVOICENUMBER'], $report->getInvoiceNumber());
-        $this->assertSame($data['BRQ_STATUSCODE'], $report->getStatusCode());
-        $this->assertSame($data['BRQ_STATUSCODE_DETAIL'], $report->getStatusCodeDetail());
-        $this->assertSame($data['BRQ_TIMESTAMP'], $report->getTimestamp()->format('Y-m-d H:i:s'));
-        $this->assertSame($data['BRQ_AMOUNT'], $report->getAmount()->getAmount() / 100);
-        $this->assertSame($data['BRQ_CURRENCY'], $report->getAmount()->getCurrency()->getCode());
-        $this->assertSame($data['BRQ_CUSTOMER_NAME'], $report->getCustomerName());
-        $this->assertSame($data['BRQ_DESCRIPTION'], $report->getDescription());
-        $this->assertSame($data['BRQ_PAYER_HASH'], $report->getPayerHash());
-        $this->assertSame($data['BRQ_PAYMENT'], $report->getPayment());
-        $this->assertSame($data['BRQ_PAYMENT_METHOD'], $report->getPaymentMethod());
-        $this->assertSame($data['BRQ_SERVICE_IDEAL_CONSUMERBIC'], $report->getConsumerBic());
-        $this->assertSame($data['BRQ_SERVICE_IDEAL_CONSUMERIBAN'], $report->getConsumerIban());
-        $this->assertSame($data['BRQ_SERVICE_IDEAL_CONSUMERISSUER'], $report->getConsumerIssuer());
-        $this->assertSame($data['BRQ_SERVICE_IDEAL_CONSUMERNAME'], $report->getConsumerName());
-        $this->assertSame($data['BRQ_TRANSACTIONS'], $report->getTransactions());
+        $this->assertSame($this->amount, $report->getAmount()->getAmount() / 100);
+        $this->assertSame($this->currency, $report->getAmount()->getCurrency()->getCode());
+        $this->assertSame($this->customerName, $report->getCustomerName());
+        $this->assertSame($this->description, $report->getDescription());
+        $this->assertSame($this->invoiceNumber, $report->getInvoiceNumber());
+        $this->assertSame($this->payerHash, $report->getPayerHash());
+        $this->assertSame($this->payment, $report->getPayment());
+        $this->assertSame($this->paymentMethod, $report->getPaymentMethod());
+        $this->assertSame($this->consumerBic, $report->getConsumerBic());
+        $this->assertSame($this->consumerIban, $report->getConsumerIban());
+        $this->assertSame($this->consumerIssuer, $report->getConsumerIssuer());
+        $this->assertSame($this->consumerName, $report->getConsumerName());
+        $this->assertSame($statuscode, $report->getStatusCode());
+        $this->assertSame($statuscodeDetail, $report->getStatusCodeDetail());
+        $this->assertSame($statusMessage, $report->getStatusMessage());
+        $this->assertSame($this->timestamp, $report->getTimestamp()->format('Y-m-d H:i:s'));
+        $this->assertSame($this->transactions, $report->getTransactions());
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_create_a_pending_report()
+    {
+        $statuscode = ResponseInterface::STATUS_PENDING_PROCESSING;
+        $statusMessage = 'Pending processing';
+
+        $data = [
+            'BRQ_AMOUNT' => $this->amount,
+            'BRQ_CURRENCY' => $this->currency,
+            'BRQ_DESCRIPTION' => $this->description,
+            'BRQ_INVOICENUMBER' => $this->invoiceNumber,
+            'BRQ_PAYMENT' => $this->payment,
+            'BRQ_PAYMENT_METHOD' => $this->paymentMethod,
+            'BRQ_SERVICE_IDEAL_CONSUMERISSUER' => $this->consumerIssuer,
+            'BRQ_STATUSCODE' => $statuscode,
+            'BRQ_STATUSMESSAGE' => $statusMessage,
+            'BRQ_TIMESTAMP' => $this->timestamp,
+            'BRQ_TRANSACTIONS' => $this->transactions,
+            'BRQ_SIGNATURE' => $this->signature
+        ];
+
+        $report = IdealTransactionReport::create($data);
+
+        $this->assertInstanceOf(ReportInterface::class, $report);
+        $this->assertSame($this->amount, $report->getAmount()->getAmount() / 100);
+        $this->assertSame($this->currency, $report->getAmount()->getCurrency()->getCode());
+        $this->assertSame($this->description, $report->getDescription());
+        $this->assertSame($this->invoiceNumber, $report->getInvoiceNumber());
+        $this->assertSame($this->payment, $report->getPayment());
+        $this->assertSame($this->paymentMethod, $report->getPaymentMethod());
+        $this->assertSame($this->consumerIssuer, $report->getConsumerIssuer());
+        $this->assertSame($statuscode, $report->getStatusCode());
+        $this->assertSame($statusMessage, $report->getStatusMessage());
+        $this->assertSame($this->timestamp, $report->getTimestamp()->format('Y-m-d H:i:s'));
+        $this->assertSame($this->transactions, $report->getTransactions());
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_create_a_failed_report()
+    {
+        $statuscode = ResponseInterface::STATUS_FAILURE;
+        $statuscodeDetail = 'S994';
+        $statusMessage = 'An error occurred while processing the transaction through DeutscheBankProcessor.';
+
+        $data = [
+            'BRQ_AMOUNT' => $this->amount,
+            'BRQ_CURRENCY' => $this->currency,
+            'BRQ_DESCRIPTION' => $this->description,
+            'BRQ_INVOICENUMBER' => $this->invoiceNumber,
+            'BRQ_PAYMENT' => $this->payment,
+            'BRQ_PAYMENT_METHOD' => $this->paymentMethod,
+            'BRQ_SERVICE_IDEAL_CONSUMERISSUER' => $this->consumerIssuer,
+            'BRQ_STATUSCODE' => $statuscode,
+            'BRQ_STATUSCODE_DETAIL' => $statuscodeDetail,
+            'BRQ_STATUSMESSAGE' => $statusMessage,
+            'BRQ_TIMESTAMP' => $this->timestamp,
+            'BRQ_TRANSACTIONS' => $this->transactions,
+            'BRQ_SIGNATURE' => $this->signature
+        ];
+
+        $report = IdealTransactionReport::create($data);
+
+        $this->assertInstanceOf(ReportInterface::class, $report);
+        $this->assertSame($this->amount, $report->getAmount()->getAmount() / 100);
+        $this->assertSame($this->currency, $report->getAmount()->getCurrency()->getCode());
+        $this->assertSame($this->description, $report->getDescription());
+        $this->assertSame($this->invoiceNumber, $report->getInvoiceNumber());
+        $this->assertSame($this->payment, $report->getPayment());
+        $this->assertSame($this->paymentMethod, $report->getPaymentMethod());
+        $this->assertSame($this->consumerIssuer, $report->getConsumerIssuer());
+        $this->assertSame($statuscode, $report->getStatusCode());
+        $this->assertSame($statuscodeDetail, $report->getStatusCodeDetail());
+        $this->assertSame($statusMessage, $report->getStatusMessage());
+        $this->assertSame($this->timestamp, $report->getTimestamp()->format('Y-m-d H:i:s'));
+        $this->assertSame($this->transactions, $report->getTransactions());
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_create_a_rejected_report()
+    {
+        $statuscode = ResponseInterface::STATUS_REJECTED;
+        $statuscodeDetail = 'S994';
+        $statusMessage = 'An error occurred while processing the transaction through DeutscheBankProcessor.';
+
+        $data = [
+            'BRQ_AMOUNT' => $this->amount,
+            'BRQ_CURRENCY' => $this->currency,
+            'BRQ_DESCRIPTION' => $this->description,
+            'BRQ_INVOICENUMBER' => $this->invoiceNumber,
+            'BRQ_PAYMENT' => $this->payment,
+            'BRQ_PAYMENT_METHOD' => $this->paymentMethod,
+            'BRQ_SERVICE_IDEAL_CONSUMERISSUER' => $this->consumerIssuer,
+            'BRQ_STATUSCODE' => $statuscode,
+            'BRQ_STATUSCODE_DETAIL' => $statuscodeDetail,
+            'BRQ_STATUSMESSAGE' => $statusMessage,
+            'BRQ_TIMESTAMP' => $this->timestamp,
+            'BRQ_TRANSACTIONS' => $this->transactions,
+            'BRQ_SIGNATURE' => $this->signature
+        ];
+
+        $report = IdealTransactionReport::create($data);
+
+        $this->assertInstanceOf(ReportInterface::class, $report);
+        $this->assertSame($this->amount, $report->getAmount()->getAmount() / 100);
+        $this->assertSame($this->currency, $report->getAmount()->getCurrency()->getCode());
+        $this->assertSame($this->description, $report->getDescription());
+        $this->assertSame($this->invoiceNumber, $report->getInvoiceNumber());
+        $this->assertSame($this->payment, $report->getPayment());
+        $this->assertSame($this->paymentMethod, $report->getPaymentMethod());
+        $this->assertSame($this->consumerIssuer, $report->getConsumerIssuer());
+        $this->assertSame($statuscode, $report->getStatusCode());
+        $this->assertSame($statuscodeDetail, $report->getStatusCodeDetail());
+        $this->assertSame($statusMessage, $report->getStatusMessage());
+        $this->assertSame($this->timestamp, $report->getTimestamp()->format('Y-m-d H:i:s'));
+        $this->assertSame($this->transactions, $report->getTransactions());
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_create_a_cancelled_report()
+    {
+        $statuscode = ResponseInterface::STATUS_CANCELLED_BY_USER;
+        $statuscodeDetail = 'S994';
+        $statusMessage = 'An error occurred while processing the transaction through DeutscheBankProcessor.';
+
+        $data = [
+            'BRQ_AMOUNT' => $this->amount,
+            'BRQ_CURRENCY' => $this->currency,
+            'BRQ_DESCRIPTION' => $this->description,
+            'BRQ_INVOICENUMBER' => $this->invoiceNumber,
+            'BRQ_PAYMENT' => $this->payment,
+            'BRQ_PAYMENT_METHOD' => $this->paymentMethod,
+            'BRQ_SERVICE_IDEAL_CONSUMERISSUER' => $this->consumerIssuer,
+            'BRQ_STATUSCODE' => $statuscode,
+            'BRQ_STATUSCODE_DETAIL' => $statuscodeDetail,
+            'BRQ_STATUSMESSAGE' => $statusMessage,
+            'BRQ_TIMESTAMP' => $this->timestamp,
+            'BRQ_TRANSACTIONS' => $this->transactions,
+            'BRQ_SIGNATURE' => $this->signature
+        ];
+
+        $report = IdealTransactionReport::create($data);
+
+        $this->assertInstanceOf(ReportInterface::class, $report);
+        $this->assertSame($this->amount, $report->getAmount()->getAmount() / 100);
+        $this->assertSame($this->currency, $report->getAmount()->getCurrency()->getCode());
+        $this->assertSame($this->description, $report->getDescription());
+        $this->assertSame($this->invoiceNumber, $report->getInvoiceNumber());
+        $this->assertSame($this->payment, $report->getPayment());
+        $this->assertSame($this->paymentMethod, $report->getPaymentMethod());
+        $this->assertSame($this->consumerIssuer, $report->getConsumerIssuer());
+        $this->assertSame($statuscode, $report->getStatusCode());
+        $this->assertSame($statuscodeDetail, $report->getStatusCodeDetail());
+        $this->assertSame($statusMessage, $report->getStatusMessage());
+        $this->assertSame($this->timestamp, $report->getTimestamp()->format('Y-m-d H:i:s'));
+        $this->assertSame($this->transactions, $report->getTransactions());
     }
 }

--- a/tests/TreeHouse/BuckarooBundle/Tests/Report/IdealTransactionReportTest.php
+++ b/tests/TreeHouse/BuckarooBundle/Tests/Report/IdealTransactionReportTest.php
@@ -241,4 +241,23 @@ class IdealTransactionReportTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($this->timestamp, $report->getTimestamp()->format('Y-m-d H:i:s'));
         $this->assertSame($this->transactions, $report->getTransactions());
     }
+
+    /**
+     * @test
+     * @expectedException \InvalidArgumentException
+     */
+    public function it_fails_when_data_is_missing()
+    {
+        $data = [
+            'BRQ_AMOUNT' => $this->amount,
+            'BRQ_CURRENCY' => $this->currency,
+            'BRQ_DESCRIPTION' => $this->description,
+            'BRQ_INVOICENUMBER' => $this->invoiceNumber,
+            'BRQ_PAYMENT' => $this->payment,
+            'BRQ_PAYMENT_METHOD' => $this->paymentMethod,
+            'BRQ_SERVICE_IDEAL_CONSUMERISSUER' => $this->consumerIssuer,
+        ];
+
+        IdealTransactionReport::create($data);
+    }
 }

--- a/tests/TreeHouse/BuckarooBundle/Tests/Report/SimpleSepaDirectDebitTransactionCreditReportTest.php
+++ b/tests/TreeHouse/BuckarooBundle/Tests/Report/SimpleSepaDirectDebitTransactionCreditReportTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace TreeHouse\BuckarooBundle\Tests\Report;
+
+use TreeHouse\BuckarooBundle\Report\ReportInterface;
+use TreeHouse\BuckarooBundle\Report\SimpleSepaDirectDebitTransactionCreditReport;
+use TreeHouse\BuckarooBundle\Response\ResponseInterface;
+
+class SimpleSepaDirectDebitTransactionCreditReportTest extends \PHPUnit_Framework_TestCase
+{
+    private $amount = 12.34;
+    private $currency = 'EUR';
+    private $customerName = 'Pietje Puk';
+    private $invoiceNumber = 123456789;
+    private $payment = 'B62963F863AF42CFB8B2CC22125DD110';
+    private $timestamp = '2015-01-01 12:34:56';
+    private $transactions = 'ADE9AB5949924D9482E10AD1920A324D';
+    private $transactionType = 'C005';
+    private $transactionMethod = 'SimpleSepaDirectDebit';
+
+    /**
+     * @test
+     */
+    public function it_can_create_a_report()
+    {
+        $statuscode = ResponseInterface::STATUS_SUCCESS;
+        $statusMessage = 'Transaction successfully processed';
+
+        $data = [
+            'BRQ_AMOUNT_CREDIT' => $this->amount,
+            'BRQ_CURRENCY' => $this->currency,
+            'BRQ_CUSTOMER_NAME' => $this->customerName,
+            'BRQ_INVOICENUMBER' => $this->invoiceNumber,
+            'BRQ_PAYMENT' => $this->payment,
+            'BRQ_TRANSACTION_METHOD' => $this->transactionMethod,
+            'BRQ_TRANSACTION_TYPE' => $this->transactionType,
+            'BRQ_STATUSCODE' => $statuscode,
+            'BRQ_STATUSMESSAGE' => $statusMessage,
+            'BRQ_TIMESTAMP' => $this->timestamp,
+            'BRQ_TRANSACTIONS' => $this->transactions,
+        ];
+
+        $report = SimpleSepaDirectDebitTransactionCreditReport::create($data);
+
+        $this->assertInstanceOf(ReportInterface::class, $report);
+        $this->assertSame($this->amount, $report->getAmount()->getAmount() / 100);
+        $this->assertSame($this->currency, $report->getAmount()->getCurrency()->getCode());
+        $this->assertSame($this->customerName, $report->getCustomerName());
+        $this->assertSame($this->invoiceNumber, $report->getInvoiceNumber());
+        $this->assertSame($this->payment, $report->getPayment());
+        $this->assertSame($this->transactionMethod, $report->getTransactionMethod());
+        $this->assertSame($this->transactionType, $report->getTransactionType());
+        $this->assertSame($statuscode, $report->getStatusCode());
+        $this->assertSame($statusMessage, $report->getStatusMessage());
+        $this->assertSame($this->timestamp, $report->getTimestamp()->format('Y-m-d H:i:s'));
+        $this->assertSame($this->transactions, $report->getTransactions());
+    }
+
+    /**
+     * @test
+     * @expectedException \RuntimeException
+     */
+    public function it_fails_when_creating_a_debit_report()
+    {
+        $statuscode = ResponseInterface::STATUS_SUCCESS;
+        $statusMessage = 'Transaction successfully processed';
+
+        $data = [
+            'BRQ_AMOUNT_CREDIT' => $this->amount,
+            'BRQ_CURRENCY' => $this->currency,
+            'BRQ_CUSTOMER_NAME' => $this->customerName,
+            'BRQ_INVOICENUMBER' => $this->invoiceNumber,
+            'BRQ_PAYMENT' => $this->payment,
+            'BRQ_TRANSACTION_METHOD' => $this->transactionMethod,
+            'BRQ_TRANSACTION_TYPE' => 'C008',
+            'BRQ_STATUSCODE' => $statuscode,
+            'BRQ_STATUSMESSAGE' => $statusMessage,
+            'BRQ_TIMESTAMP' => $this->timestamp,
+            'BRQ_TRANSACTIONS' => $this->transactions,
+        ];
+
+        SimpleSepaDirectDebitTransactionCreditReport::create($data);
+    }
+
+    /**
+     * @test
+     * @expectedException \InvalidArgumentException
+     */
+    public function it_fails_when_data_is_missing()
+    {
+        $data = [
+            'BRQ_AMOUNT_CREDIT' => $this->amount,
+            'BRQ_CURRENCY' => $this->currency,
+            'BRQ_CUSTOMER_NAME' => $this->customerName,
+            'BRQ_INVOICENUMBER' => $this->invoiceNumber,
+            'BRQ_PAYMENT' => $this->payment,
+            'BRQ_TRANSACTION_METHOD' => $this->transactionMethod,
+            'BRQ_TRANSACTION_TYPE' => $this->transactionType,
+            'BRQ_TRANSACTIONS' => $this->transactions,
+        ];
+
+        SimpleSepaDirectDebitTransactionCreditReport::create($data);
+    }
+}

--- a/tests/TreeHouse/BuckarooBundle/Tests/Report/SimpleSepaDirectDebitTransactionDebitReportTest.php
+++ b/tests/TreeHouse/BuckarooBundle/Tests/Report/SimpleSepaDirectDebitTransactionDebitReportTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace TreeHouse\BuckarooBundle\Tests\Report;
+
+use TreeHouse\BuckarooBundle\Report\ReportInterface;
+use TreeHouse\BuckarooBundle\Report\SimpleSepaDirectDebitTransactionDebitReport;
+use TreeHouse\BuckarooBundle\Response\ResponseInterface;
+
+class SimpleSepaDirectDebitTransactionDebitReportTest extends \PHPUnit_Framework_TestCase
+{
+    private $amount = 12.34;
+    private $currency = 'EUR';
+    private $customerName = 'Pietje Puk';
+    private $invoiceNumber = 123456789;
+    private $payment = 'B62963F863AF42CFB8B2CC22125DD110';
+    private $customerIban = 'NL12ING0123456789';
+    private $timestamp = '2015-01-01 12:34:56';
+    private $collectDate = '2015-01-02 12:34:56';
+    private $mandateDate = '2015-01-03 12:34:56';
+    private $mandateReference = 'ABC1234';
+    private $transactions = 'ADE9AB5949924D9482E10AD1920A324D';
+    private $startRecurrent = true;
+    private $directDebitType = 'Recurring';
+    private $transactionType = 'C008';
+    private $transactionMethod = 'SimpleSepaDirectDebit';
+
+    /**
+     * @test
+     */
+    public function it_can_create_a_report()
+    {
+        $statuscode = ResponseInterface::STATUS_SUCCESS;
+        $statusMessage = 'Transaction successfully processed';
+
+        $data = [
+            'BRQ_INVOICENUMBER' => $this->invoiceNumber,
+            'BRQ_STATUSCODE' => $statuscode,
+            'BRQ_STATUSMESSAGE' => $statusMessage,
+            'BRQ_TIMESTAMP' => $this->timestamp,
+            'BRQ_AMOUNT' => $this->amount,
+            'BRQ_CURRENCY' => $this->currency,
+            'BRQ_CUSTOMER_NAME' => $this->customerName,
+            'BRQ_PAYMENT' => $this->payment,
+            'BRQ_SERVICE_SIMPLESEPADIRECTDEBIT_COLLECTDATE' => $this->collectDate,
+            'BRQ_SERVICE_SIMPLESEPADIRECTDEBIT_CUSTOMERIBAN' => $this->customerIban,
+            'BRQ_SERVICE_SIMPLESEPADIRECTDEBIT_DIRECTDEBITTYPE' => $this->directDebitType,
+            'BRQ_SERVICE_SIMPLESEPADIRECTDEBIT_MANDATEDATE' => $this->mandateDate,
+            'BRQ_SERVICE_SIMPLESEPADIRECTDEBIT_MANDATEREFERENCE' => $this->mandateReference,
+            'BRQ_STARTRECURRENT' => $this->startRecurrent,
+            'BRQ_TRANSACTION_METHOD' => $this->transactionMethod,
+            'BRQ_TRANSACTION_TYPE' => $this->transactionType,
+            'BRQ_TRANSACTIONS' => $this->transactions,
+        ];
+
+        $report = SimpleSepaDirectDebitTransactionDebitReport::create($data);
+
+        $this->assertInstanceOf(ReportInterface::class, $report);
+        $this->assertSame($this->amount, $report->getAmount()->getAmount() / 100);
+        $this->assertSame($this->currency, $report->getAmount()->getCurrency()->getCode());
+        $this->assertSame($this->customerName, $report->getCustomerName());
+        $this->assertSame($this->invoiceNumber, $report->getInvoiceNumber());
+        $this->assertSame($this->payment, $report->getPayment());
+        $this->assertSame($this->collectDate, $report->getCollectDate()->format('Y-m-d H:i:s'));
+        $this->assertSame($this->customerIban, $report->getCustomerIban());
+        $this->assertSame($this->directDebitType, $report->getDirectDebitType());
+        $this->assertSame($this->mandateDate, $report->getMandateDate()->format('Y-m-d H:i:s'));
+        $this->assertSame($this->mandateReference, $report->getMandateReference());
+        $this->assertSame($statuscode, $report->getStatusCode());
+        $this->assertSame($statusMessage, $report->getStatusMessage());
+        $this->assertSame($this->timestamp, $report->getTimestamp()->format('Y-m-d H:i:s'));
+        $this->assertSame($this->transactions, $report->getTransactions());
+    }
+
+    /**
+     * @test
+     * @expectedException \RuntimeException
+     */
+    public function it_fails_when_creating_a_credit_report()
+    {
+        $statuscode = ResponseInterface::STATUS_SUCCESS;
+        $statusMessage = 'Transaction successfully processed';
+
+        $data = [
+            'BRQ_INVOICENUMBER' => $this->invoiceNumber,
+            'BRQ_STATUSCODE' => $statuscode,
+            'BRQ_STATUSMESSAGE' => $statusMessage,
+            'BRQ_TIMESTAMP' => $this->timestamp,
+            'BRQ_AMOUNT' => $this->amount,
+            'BRQ_CURRENCY' => $this->currency,
+            'BRQ_CUSTOMER_NAME' => $this->customerName,
+            'BRQ_PAYMENT' => $this->payment,
+            'BRQ_SERVICE_SIMPLESEPADIRECTDEBIT_COLLECTDATE' => $this->collectDate,
+            'BRQ_SERVICE_SIMPLESEPADIRECTDEBIT_CUSTOMERIBAN' => $this->customerIban,
+            'BRQ_SERVICE_SIMPLESEPADIRECTDEBIT_DIRECTDEBITTYPE' => $this->directDebitType,
+            'BRQ_SERVICE_SIMPLESEPADIRECTDEBIT_MANDATEDATE' => $this->mandateDate,
+            'BRQ_SERVICE_SIMPLESEPADIRECTDEBIT_MANDATEREFERENCE' => $this->mandateReference,
+            'BRQ_STARTRECURRENT' => $this->startRecurrent,
+            'BRQ_TRANSACTION_METHOD' => $this->transactionMethod,
+            'BRQ_TRANSACTION_TYPE' => 'C005',
+            'BRQ_TRANSACTIONS' => $this->transactions,
+        ];
+
+        SimpleSepaDirectDebitTransactionDebitReport::create($data);
+    }
+
+    /**
+     * @test
+     * @expectedException \InvalidArgumentException
+     */
+    public function it_fails_when_data_is_missing()
+    {
+        $statuscode = ResponseInterface::STATUS_SUCCESS;
+        $statusMessage = 'Transaction successfully processed';
+
+        $data = [
+            'BRQ_INVOICENUMBER' => $this->invoiceNumber,
+            'BRQ_STATUSCODE' => $statuscode,
+            'BRQ_STATUSMESSAGE' => $statusMessage,
+            'BRQ_TIMESTAMP' => $this->timestamp,
+            'BRQ_AMOUNT' => $this->amount,
+            'BRQ_CURRENCY' => $this->currency,
+            'BRQ_TRANSACTION_TYPE' => $this->transactionType,
+            'BRQ_TRANSACTIONS' => $this->transactions,
+        ];
+
+        SimpleSepaDirectDebitTransactionDebitReport::create($data);
+    }
+}


### PR DESCRIPTION
iDeal transactions have less fields when the report is not success (ie: cancelled, rejected, failed, etc.). This PR fixes the report class in that it does not require those fields to create it.

Added tests for all types of iDeal transaction reports.