### PR TITLE
Make transaction method optional

### DIFF
--- a/src/TreeHouse/BuckarooBundle/Report/AbstractSimpleSepaDirectDebitTransactionReport.php
+++ b/src/TreeHouse/BuckarooBundle/Report/AbstractSimpleSepaDirectDebitTransactionReport.php
@@ -6,8 +6,6 @@ use Money\Money;
 
 abstract class AbstractSimpleSepaDirectDebitTransactionReport extends AbstractTransactionReport
 {
-    public const DEFAULT_TRANSACTION_METHOD = 'SimpleSepaDirectDebit';
-
     /**
      * The amount for the transaction.
      *

--- a/src/TreeHouse/BuckarooBundle/Report/AbstractSimpleSepaDirectDebitTransactionReport.php
+++ b/src/TreeHouse/BuckarooBundle/Report/AbstractSimpleSepaDirectDebitTransactionReport.php
@@ -6,6 +6,8 @@ use Money\Money;
 
 abstract class AbstractSimpleSepaDirectDebitTransactionReport extends AbstractTransactionReport
 {
+    public const DEFAULT_TRANSACTION_METHOD = 'SimpleSepaDirectDebit';
+
     /**
      * The amount for the transaction.
      *

--- a/src/TreeHouse/BuckarooBundle/Report/SimpleSepaDirectDebitTransactionCreditReport.php
+++ b/src/TreeHouse/BuckarooBundle/Report/SimpleSepaDirectDebitTransactionCreditReport.php
@@ -63,7 +63,7 @@ class SimpleSepaDirectDebitTransactionCreditReport extends AbstractSimpleSepaDir
         $report->customerName = $data['BRQ_CUSTOMER_NAME'];
         $report->invoiceNumber = $data['BRQ_INVOICENUMBER'];
         $report->payment = $data['BRQ_PAYMENT'];
-        $report->transactionMethod = isset($data['BRQ_TRANSACTION_METHOD']) ? $data['BRQ_TRANSACTION_METHOD'] : AbstractSimpleSepaDirectDebitTransactionReport::DEFAULT_TRANSACTION_METHOD;
+        $report->transactionMethod = isset($data['BRQ_TRANSACTION_METHOD']) ? $data['BRQ_TRANSACTION_METHOD'] : null;
         $report->transactionType = $data['BRQ_TRANSACTION_TYPE'];
         $report->transactions = $data['BRQ_TRANSACTIONS'];
         $report->reasonCode = $data['BRQ_SERVICE_SIMPLESEPADIRECTDEBIT_REASONCODE'];

--- a/src/TreeHouse/BuckarooBundle/Report/SimpleSepaDirectDebitTransactionCreditReport.php
+++ b/src/TreeHouse/BuckarooBundle/Report/SimpleSepaDirectDebitTransactionCreditReport.php
@@ -36,7 +36,6 @@ class SimpleSepaDirectDebitTransactionCreditReport extends AbstractSimpleSepaDir
             'BRQ_CUSTOMER_NAME',
             'BRQ_INVOICENUMBER',
             'BRQ_PAYMENT',
-            'BRQ_TRANSACTION_METHOD',
             'BRQ_TRANSACTION_TYPE',
         ];
 
@@ -64,7 +63,7 @@ class SimpleSepaDirectDebitTransactionCreditReport extends AbstractSimpleSepaDir
         $report->customerName = $data['BRQ_CUSTOMER_NAME'];
         $report->invoiceNumber = $data['BRQ_INVOICENUMBER'];
         $report->payment = $data['BRQ_PAYMENT'];
-        $report->transactionMethod = $data['BRQ_TRANSACTION_METHOD'];
+        $report->transactionMethod = isset($data['BRQ_TRANSACTION_METHOD']) ? $data['BRQ_TRANSACTION_METHOD'] : AbstractSimpleSepaDirectDebitTransactionReport::DEFAULT_TRANSACTION_METHOD;
         $report->transactionType = $data['BRQ_TRANSACTION_TYPE'];
         $report->transactions = $data['BRQ_TRANSACTIONS'];
         $report->reasonCode = $data['BRQ_SERVICE_SIMPLESEPADIRECTDEBIT_REASONCODE'];

--- a/src/TreeHouse/BuckarooBundle/Report/SimpleSepaDirectDebitTransactionDebitReport.php
+++ b/src/TreeHouse/BuckarooBundle/Report/SimpleSepaDirectDebitTransactionDebitReport.php
@@ -54,7 +54,7 @@ class SimpleSepaDirectDebitTransactionDebitReport extends AbstractSimpleSepaDire
         $report->mandateDate = new \DateTime($data['BRQ_SERVICE_SIMPLESEPADIRECTDEBIT_MANDATEDATE']);
         $report->mandateReference = $data['BRQ_SERVICE_SIMPLESEPADIRECTDEBIT_MANDATEREFERENCE'];
         $report->startRecurrent = (bool) $data['BRQ_STARTRECURRENT'];
-        $report->transactionMethod = isset($data['BRQ_TRANSACTION_METHOD']) ? $data['BRQ_TRANSACTION_METHOD'] : AbstractSimpleSepaDirectDebitTransactionReport::DEFAULT_TRANSACTION_METHOD;
+        $report->transactionMethod = isset($data['BRQ_TRANSACTION_METHOD']) ? $data['BRQ_TRANSACTION_METHOD'] : null;
         $report->transactionType = $data['BRQ_TRANSACTION_TYPE'];
 
         return $report;

--- a/src/TreeHouse/BuckarooBundle/Report/SimpleSepaDirectDebitTransactionDebitReport.php
+++ b/src/TreeHouse/BuckarooBundle/Report/SimpleSepaDirectDebitTransactionDebitReport.php
@@ -26,7 +26,6 @@ class SimpleSepaDirectDebitTransactionDebitReport extends AbstractSimpleSepaDire
             'BRQ_SERVICE_SIMPLESEPADIRECTDEBIT_MANDATEDATE',
             'BRQ_SERVICE_SIMPLESEPADIRECTDEBIT_MANDATEREFERENCE',
             'BRQ_STARTRECURRENT',
-            'BRQ_TRANSACTION_METHOD',
             'BRQ_TRANSACTION_TYPE',
         ];
 
@@ -55,7 +54,7 @@ class SimpleSepaDirectDebitTransactionDebitReport extends AbstractSimpleSepaDire
         $report->mandateDate = new \DateTime($data['BRQ_SERVICE_SIMPLESEPADIRECTDEBIT_MANDATEDATE']);
         $report->mandateReference = $data['BRQ_SERVICE_SIMPLESEPADIRECTDEBIT_MANDATEREFERENCE'];
         $report->startRecurrent = (bool) $data['BRQ_STARTRECURRENT'];
-        $report->transactionMethod = $data['BRQ_TRANSACTION_METHOD'];
+        $report->transactionMethod = isset($data['BRQ_TRANSACTION_METHOD']) ? $data['BRQ_TRANSACTION_METHOD'] : AbstractSimpleSepaDirectDebitTransactionReport::DEFAULT_TRANSACTION_METHOD;
         $report->transactionType = $data['BRQ_TRANSACTION_TYPE'];
 
         return $report;

--- a/src/TreeHouse/BuckarooBundle/Report/TransferTransactionReport.php
+++ b/src/TreeHouse/BuckarooBundle/Report/TransferTransactionReport.php
@@ -65,7 +65,7 @@ class TransferTransactionReport extends AbstractTransactionReport
         $report->amount = new Money(intval($data['BRQ_AMOUNT'] * 100), new Currency($data['BRQ_CURRENCY']));
         $report->description = $data['BRQ_DESCRIPTION'];
         $report->payment = $data['BRQ_PAYMENT'];
-        $report->transactionMethod = $data['BRQ_TRANSACTION_METHOD'] ?: AbstractSimpleSepaDirectDebitTransactionReport::DEFAULT_TRANSACTION_METHOD;
+        $report->transactionMethod = isset($data['BRQ_TRANSACTION_METHOD']) ? $data['BRQ_TRANSACTION_METHOD'] : null;
         $report->transactionType = $data['BRQ_TRANSACTION_TYPE'];
 
         return $report;

--- a/src/TreeHouse/BuckarooBundle/Report/TransferTransactionReport.php
+++ b/src/TreeHouse/BuckarooBundle/Report/TransferTransactionReport.php
@@ -49,7 +49,6 @@ class TransferTransactionReport extends AbstractTransactionReport
             'BRQ_STATUSMESSAGE',
             'BRQ_TIMESTAMP',
             'BRQ_TRANSACTIONS',
-            'BRQ_TRANSACTION_METHOD',
             'BRQ_TRANSACTION_TYPE',
         ];
 
@@ -66,7 +65,7 @@ class TransferTransactionReport extends AbstractTransactionReport
         $report->amount = new Money(intval($data['BRQ_AMOUNT'] * 100), new Currency($data['BRQ_CURRENCY']));
         $report->description = $data['BRQ_DESCRIPTION'];
         $report->payment = $data['BRQ_PAYMENT'];
-        $report->transactionMethod = $data['BRQ_TRANSACTION_METHOD'];
+        $report->transactionMethod = $data['BRQ_TRANSACTION_METHOD'] ?: AbstractSimpleSepaDirectDebitTransactionReport::DEFAULT_TRANSACTION_METHOD;
         $report->transactionType = $data['BRQ_TRANSACTION_TYPE'];
 
         return $report;

--- a/tests/TreeHouse/BuckarooBundle/Tests/Report/SimpleSepaDirectDebitTransactionCreditReportTest.php
+++ b/tests/TreeHouse/BuckarooBundle/Tests/Report/SimpleSepaDirectDebitTransactionCreditReportTest.php
@@ -34,7 +34,6 @@ class SimpleSepaDirectDebitTransactionCreditReportTest extends \PHPUnit_Framewor
             'BRQ_CUSTOMER_NAME' => $this->customerName,
             'BRQ_INVOICENUMBER' => $this->invoiceNumber,
             'BRQ_PAYMENT' => $this->payment,
-            'BRQ_TRANSACTION_METHOD' => $this->transactionMethod,
             'BRQ_TRANSACTION_TYPE' => $this->transactionType,
             'BRQ_STATUSCODE' => $statuscode,
             'BRQ_STATUSMESSAGE' => $statusMessage,

--- a/tests/TreeHouse/BuckarooBundle/Tests/Report/SimpleSepaDirectDebitTransactionCreditReportTest.php
+++ b/tests/TreeHouse/BuckarooBundle/Tests/Report/SimpleSepaDirectDebitTransactionCreditReportTest.php
@@ -51,7 +51,7 @@ class SimpleSepaDirectDebitTransactionCreditReportTest extends \PHPUnit_Framewor
         $this->assertSame($this->customerName, $report->getCustomerName());
         $this->assertSame($this->invoiceNumber, $report->getInvoiceNumber());
         $this->assertSame($this->payment, $report->getPayment());
-        $this->assertSame($this->transactionMethod, $report->getTransactionMethod());
+        $this->assertNull($report->getTransactionMethod());
         $this->assertSame($this->transactionType, $report->getTransactionType());
         $this->assertSame($statuscode, $report->getStatusCode());
         $this->assertSame($statusMessage, $report->getStatusMessage());
@@ -76,7 +76,6 @@ class SimpleSepaDirectDebitTransactionCreditReportTest extends \PHPUnit_Framewor
             'BRQ_CUSTOMER_NAME' => $this->customerName,
             'BRQ_INVOICENUMBER' => $this->invoiceNumber,
             'BRQ_PAYMENT' => $this->payment,
-            'BRQ_TRANSACTION_METHOD' => $this->transactionMethod,
             'BRQ_TRANSACTION_TYPE' => 'C008',
             'BRQ_STATUSCODE' => $statuscode,
             'BRQ_STATUSMESSAGE' => $statusMessage,

--- a/tests/TreeHouse/BuckarooBundle/Tests/Report/SimpleSepaDirectDebitTransactionDebitReportTest.php
+++ b/tests/TreeHouse/BuckarooBundle/Tests/Report/SimpleSepaDirectDebitTransactionDebitReportTest.php
@@ -47,7 +47,6 @@ class SimpleSepaDirectDebitTransactionDebitReportTest extends \PHPUnit_Framework
             'BRQ_SERVICE_SIMPLESEPADIRECTDEBIT_MANDATEDATE' => $this->mandateDate,
             'BRQ_SERVICE_SIMPLESEPADIRECTDEBIT_MANDATEREFERENCE' => $this->mandateReference,
             'BRQ_STARTRECURRENT' => $this->startRecurrent,
-            'BRQ_TRANSACTION_METHOD' => $this->transactionMethod,
             'BRQ_TRANSACTION_TYPE' => $this->transactionType,
             'BRQ_TRANSACTIONS' => $this->transactions,
         ];
@@ -95,7 +94,6 @@ class SimpleSepaDirectDebitTransactionDebitReportTest extends \PHPUnit_Framework
             'BRQ_SERVICE_SIMPLESEPADIRECTDEBIT_MANDATEDATE' => $this->mandateDate,
             'BRQ_SERVICE_SIMPLESEPADIRECTDEBIT_MANDATEREFERENCE' => $this->mandateReference,
             'BRQ_STARTRECURRENT' => $this->startRecurrent,
-            'BRQ_TRANSACTION_METHOD' => $this->transactionMethod,
             'BRQ_TRANSACTION_TYPE' => 'C005',
             'BRQ_TRANSACTIONS' => $this->transactions,
         ];

--- a/tests/TreeHouse/BuckarooBundle/Tests/Report/TransferTransactionReportTest.php
+++ b/tests/TreeHouse/BuckarooBundle/Tests/Report/TransferTransactionReportTest.php
@@ -18,7 +18,6 @@ class TransferTransactionReportTest extends \PHPUnit_Framework_TestCase
     private $test = false;
     private $timestamp = '2015-01-01 12:34:56';
     private $transactions = 'ADE9AB5949924D9482E10AD1920A324D';
-    private $transactionMethod = 'transfer';
     private $transactionType = 'C001';
     private $signature = '5TzIZWifLXr2gtXlYoc93dewnnY3noZWakZhtiO8';
     private $websitekey = '123456789';
@@ -44,7 +43,7 @@ class TransferTransactionReportTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($this->statusCodeDetail, $report->getStatusCodeDetail());
         $this->assertSame($this->statusMessage, $report->getStatusMessage());
         $this->assertSame($this->timestamp, $report->getTimestamp()->format('Y-m-d H:i:s'));
-        $this->assertSame($this->transactionMethod, $report->getTransactionMethod());
+        $this->assertNull($report->getTransactionMethod());
         $this->assertSame($this->transactionType, $report->getTransactionType());
         $this->assertSame($this->transactions, $report->getTransactions());
     }
@@ -84,7 +83,6 @@ class TransferTransactionReportTest extends \PHPUnit_Framework_TestCase
             'BRQ_STATUSMESSAGE' => $this->statusMessage,
             'BRQ_TEST' => $this->test,
             'BRQ_TIMESTAMP' => $this->timestamp,
-            'BRQ_TRANSACTION_METHOD' => $this->transactionMethod,
             'BRQ_TRANSACTION_TYPE' => $this->transactionType,
             'BRQ_TRANSACTIONS' => $this->transactions,
             'BRQ_WEBSITEKEY' => $this->websitekey,


### PR DESCRIPTION
Since last night we've had problems processing rejected payments being sent to us from Buckaroo. This was being caused by the `BRQ_TRANSACTION_METHOD` field which was missing.

We've already contact Buckaroo and they are looking into it. In the mean while, their docs state this field is optional when they send us data so essentially they did not do anything "wrong". However is is of course pretty inconvenient if they always send it and suddenly don't anymore.

To fix the problem at hand I have made the field optional and gave it a default value so it won't fail anymore.